### PR TITLE
Auto generate config.yaml on shell start

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ views:
       command: ls -la
 ```
 
-For generating view from `config.yml` file go to its folder:
+To apply changes, either restart `zsh`, resource `~/.zshrc` by running `source ~/.zshrc`, or  go to its folder:
 
 ```sh
 cd $ZSH_CUSTOM/plugins/zsh-apple-touchbar

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ views:
       command: ls -la
 ```
 
-To apply changes, either restart `zsh`, resource `~/.zshrc` by running `source ~/.zshrc`, or  go to its folder:
+To apply changes, either restart `zsh`, resource `~/.zshrc` by running `source ~/.zshrc`, or go to its folder:
 
 ```sh
 cd $ZSH_CUSTOM/plugins/zsh-apple-touchbar
 ```
-
-and run `generate.rb` file:
+and run `source zsh-apply-touchbar.zsh`,  
+or run `generate.rb` file:
 
 ```sh
 ruby generate.rb

--- a/config.yml
+++ b/config.yml
@@ -23,5 +23,5 @@ views:
       text: 👈 back
       view: first
     2:
-      text: ls
+      text: Hello
       command: ls -la

--- a/config.yml
+++ b/config.yml
@@ -23,5 +23,5 @@ views:
       text: 👈 back
       view: first
     2:
-      text: Hello
+      text: ls
       command: ls -la

--- a/generate.rb
+++ b/generate.rb
@@ -5,19 +5,16 @@ class Parser
     new(*args).call
   end
 
-  def initialize(file_path = 'config.yml')
+  def initialize(file_path = __dir__+'/config.yml')
     @file_path = file_path
   end
 
   def call
     [].tap do |code|
-      code << 'source ${0:A:h}/functions.zsh'
       code << "set_state '#{config['default_view']}'"
       code << views_functions
       code << define_views_functions
       code << main_function
-      code << 'autoload -Uz add-zsh-hook'
-      code << "add-zsh-hook precmd precmd_apple_touchbar\n"
     end.join("\n\n")
   end
 
@@ -74,4 +71,4 @@ class Parser
   end
 end
 
-File.open('zsh-apple-touchbar.zsh', 'w') {|f| f.write(Parser.call) }
+File.open(__dir__+'/touchbar-mappings.zsh', 'w') {|f| f.write(Parser.call) }

--- a/touchbar-mappings.zsh
+++ b/touchbar-mappings.zsh
@@ -27,7 +27,7 @@ function third_view() {
 	set_state 'third'
 
 	create_key 1 '👈 back' 'first_view'
-	create_key 2 'Hello' 'ls -la' '-s'
+	create_key 2 'ls' 'ls -la' '-s'
 }
 
 zle -N first_view

--- a/touchbar-mappings.zsh
+++ b/touchbar-mappings.zsh
@@ -1,0 +1,43 @@
+set_state 'first'
+
+function first_view() {
+	remove_and_unbind_keys
+
+	set_state 'first'
+
+	create_key 1 '👉 pwd' 'pwd |tr -d "\\n" |pbcopy' '-s'
+	create_key 2 'second view' 'second_view'
+	create_key 3 'third view' 'third_view'
+}
+
+function second_view() {
+	remove_and_unbind_keys
+
+	set_state 'second'
+
+	create_key 1 '👈 back' 'first_view'
+	create_key 2 'current path' 'pwd' '-s'
+
+	set_state 'first'
+}
+
+function third_view() {
+	remove_and_unbind_keys
+
+	set_state 'third'
+
+	create_key 1 '👈 back' 'first_view'
+	create_key 2 'Hello' 'ls -la' '-s'
+}
+
+zle -N first_view
+zle -N second_view
+zle -N third_view
+
+precmd_apple_touchbar() {
+	case $state in
+		first) first_view ;;
+		second) second_view ;;
+		third) third_view ;;
+	esac
+}

--- a/zsh-apple-touchbar.zsh
+++ b/zsh-apple-touchbar.zsh
@@ -1,48 +1,8 @@
 source ${0:A:h}/functions.zsh
 
-set_state 'first'
+ruby ${0:A:h}/generate.rb
 
-function first_view() {
-	remove_and_unbind_keys
-
-	set_state 'first'
-
-	create_key 1 '👉 pwd' 'pwd |tr -d "\\n" |pbcopy' '-s'
-	create_key 2 'second view' 'second_view'
-	create_key 3 'third view' 'third_view'
-}
-
-function second_view() {
-	remove_and_unbind_keys
-
-	set_state 'second'
-
-	create_key 1 '👈 back' 'first_view'
-	create_key 2 'current path' 'pwd' '-s'
-
-	set_state 'first'
-}
-
-function third_view() {
-	remove_and_unbind_keys
-
-	set_state 'third'
-
-	create_key 1 '👈 back' 'first_view'
-	create_key 2 'ls' 'ls -la' '-s'
-}
-
-zle -N first_view
-zle -N second_view
-zle -N third_view
-
-precmd_apple_touchbar() {
-	case $state in
-		first) first_view ;;
-		second) second_view ;;
-		third) third_view ;;
-	esac
-}
+source ${0:A:h}/touchbar-mappings.zsh
 
 autoload -Uz add-zsh-hook
 


### PR DESCRIPTION
I think the current instruction for updating keys is _slightly_ unintuitive
Having to manually run `ruby generate.rb` is different than the way users might expect.  Instead, I think it makes more sense to ask users to resource `~/.zshrc` or restart their terminal.

I don't think it's BETTER to restart zsh/resource `~/.zshrc` (in fact, it's actually slower), but rather it fits more in line with standard command-line tools conventions.  Most CLI tools I know of may ask users to restart/resource their shell to apply changes.

Anyways, this PR isn't trying to change any functionality of zsh-apple-touchbar, just making a bit more sense for once process