### PR TITLE
add tmux support

### DIFF
--- a/functions.zsh
+++ b/functions.zsh
@@ -1,5 +1,10 @@
 function print_key() {
-  echo -ne $*
+  if [ -n "$TMUX" ]
+  then
+    echo -ne "\ePtmux;\e$*\e\\"
+  else
+    echo -ne $*
+  fi
 }
 
 function remove_keys() {


### PR DESCRIPTION
When you use tmux, some of the functions not work (for example button clearing).
This is because tmux catches unknown escape sequences. By adding `\ePtmux;\e[...]\e\\` you can tell tmux not to catch these, and the touchbar will work properly.